### PR TITLE
Attempt to Fix Tab Bug

### DIFF
--- a/pages/academy/about-oha.md
+++ b/pages/academy/about-oha.md
@@ -1,5 +1,7 @@
 ---
 title: About OHA
-layout: page
-sort: 1
+layout: default
+permalink: /pages/academy/about-oha/
+redirect: /pages/academy/about-oha/our-history.html
 ---
+


### PR DESCRIPTION
CAUTION. Theoretically–in my mind–this should redirect how we want it. I changed the "about oha" tab into the same type of link that the homepage has with Academy, College, etc. So it shouldn't be a page and it redirects to the first page of the sub categories of the tab and the other selections would be on the side as it was before. 

The think is, I don't know exactly what will happen because this is under the pages section and I don't know if changing the state of the page somehow modifies the subpages. So I only did one to try it out. Because of the state of my computer, I cannot view the changes myself in my own repository, which is why I'm making a pull request.
